### PR TITLE
Debugger statements should not be used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "alert": "^5.0.10",
+        "debug": "^4.3.4",
         "request": "^2.88.2"
       }
     },
@@ -118,6 +119,22 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/delayed-stream": {
@@ -298,6 +315,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
@@ -553,6 +575,14 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -692,6 +722,11 @@
       "requires": {
         "mime-db": "1.52.0"
       }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "oauth-sign": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/wheelyumdev-test/sonar#readme",
   "dependencies": {
     "alert": "^5.0.10",
+    "debug": "^4.3.4",
     "request": "^2.88.2"
   }
 }

--- a/vulnerability/28/index.js
+++ b/vulnerability/28/index.js
@@ -1,0 +1,10 @@
+var Debug = require("debug");
+
+for (i = 1; i < 5; i++) {
+  // Print i to the Output window.
+  // Debug.write("loop index is " + i);
+  Debug.debug("loop index is " + i);
+  console.debug("loop index is " + i);
+  // Wait for user to resume.
+  debugger;
+}

--- a/vulnerability/index.js
+++ b/vulnerability/index.js
@@ -1,6 +1,10 @@
 // 17: Server hostnames should be verified during SSL/TLS connections
 require("./17");
 
+// 28: Debugger statements should not be used
+// DEPRECATED: This rule is deprecated; use {rule:javascript:S4507} instead.
+require("./28");
+
 // 29: "alert(...)" should not be used
 // DEPRECATED: This rule is deprecated; use {rule:javascript:S4507} instead.
 require("./29");


### PR DESCRIPTION
The debugger statement can be placed anywhere in procedures to suspend execution. Using the debugger statement is similar to setting a breakpoint in the code. By definition 
such statement must absolutely be removed from the source code to prevent any unexpected behavior or added vulnerability to attacks in production.
